### PR TITLE
add new projects and update GitHub links in the portfolio

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,20 +3,30 @@ import Layout from '../layouts/Layout.astro';
 import ProjectCard from '../components/ProjectCard.astro';
 import TechBadge from '../components/TechBadge.astro';
 // import Card from '../components/Card.astro';
+//
+const githubUrl = "https://github.com"
+const myGithubUrl = githubUrl + "/bernoussama";
 
 const projects = [
+	{
+		src: "images/lazyshell-image.webp",
+		title: "LazyShell - AI CLI",
+		body: "A CLI tool that uses generative AI to generate shell commands",
+		href: myGithubUrl + "/lazyshell",
+		techs: ["AI", "CLI", "Shell", "Linux", "OpenAI", "Anthropic", "Claude"]
+	},
 	{
 		src: "images/dns-image.webp",
 		title: "Mercury - DNS Server from scratch",
 		body: "Authoritave and recursive DNS server built from scratch in Go",
-		href: "https://github.com/0ussamaBernou/mercury",
+		href: myGithubUrl + "/mercury",
     techs: ["DNS Server", "From Scratch", "Go"]
 	},
 	{
 		src: "images/simplinvo-image.webp",
 		title: "Simplinvo - Invoicing App",
 		body: "Invoicing solution built with Remix, PocketBase and Tailwind",
-		href: "https://github.com/0ussamaBernou/simplinvo",
+		href: myGithubUrl + "/simplinvo",
     techs: [ "React", "Remix", "Tailwind", "PocketBase", "Go", "SPA"]
 	},
 	{
@@ -30,21 +40,21 @@ const projects = [
 		src: "images/yanc-image.webp",
     title: "YANC - Yet Another Netflix Clone",
 		body: "YANC is yet another Netflix clone built with Next.js 15, Tailwind and TMDB API",
-		href: "https://github.com/0ussamaBernou/yanc",
+		href: myGithubUrl + "/yanc",
 		techs: ["React", "Next.js", "Tailwind"]
 	},
 	{
 		src: "images/portfolio-image.webp",
 		title: "My Portfolio & Personal blog",
 		body: "A fully responsive Portfolio & personal blog built with Astro and Tailwind",
-		href: "https://github.com/0ussamaBernou/my-portfolio",
+		href: myGithubUrl + "/my-portfolio",
 		techs: ["HTML5", "Astro", "Tailwind", "Franken-UI"]
 	},
 	{
 		src: "images/desktop-preview.webp",
 		title: "Fylo - Responsive Landing Page",
 		body: "HTML5 & CSS3 - A fully responsive landing page for a software product",
-		href: "https://github.com/0ussamaBernou/fylo-landing-page",
+		href: myGithubUrl + "/fylo-landing-page",
 		demoUrl: "https://fylo.bernoussama.com/",
 		techs: ["HTML5", "CSS3"]
 	},
@@ -52,13 +62,13 @@ const projects = [
 		src: "images/Source-project.webp",
 		title: "Source - Responsive Template",
 		body: "A fully responsive multi-purpose landing page template",
-		href: "https://github.com/0ussamaBernou/source-layout",
+		href: myGithubUrl + "/source-layout",
 		techs: ["HTML5", "CSS3"]
 	},
 	{
 		src: "https://images.pexels.com/photos/270408/pexels-photo-270408.jpeg?auto=compress&cs=tinysrgb&w=720&dpr=2",
 		title: "More projects...",
-		href: "https://github.com/0ussamaBernou",
+		href: myGithubUrl,
 		buttonText: "View More"
 	}
 ];
@@ -83,7 +93,7 @@ const projects = [
 					through software.
 				</h3>
 				<div class="flex w-full items-center justify-center space-x-4 py-4 md:pb-10">
-					<a class="uk-button uk-button-primary gap-x-2" href="https://github.com/0ussamaBernou"
+					<a class="uk-button uk-button-primary gap-x-2" href={myGithubUrl}
 						target="_blank">
 						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
 							stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ const myGithubUrl = githubUrl + "/bernoussama";
 
 const projects = [
 	{
-		src: "images/lazyshell-image.webp",
+		src: "https://private-user-images.githubusercontent.com/96293508/449571348-1699d100-d73a-43d9-8b69-5ba8e50fcdc7.gif?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTExNTU4MTksIm5iZiI6MTc1MTE1NTUxOSwicGF0aCI6Ii85NjI5MzUwOC80NDk1NzEzNDgtMTY5OWQxMDAtZDczYS00M2Q5LThiNjktNWJhOGU1MGZjZGM3LmdpZj9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA2MjklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNjI5VDAwMDUxOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTJjNWMyM2I2MzQ3NTlmZjc4YjYyZmNjMGMzNDcxNWJkY2IzM2ZkMDg1ZDZkZjQxMjhmZTM5YzZhNDJkYmExNWUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.Wzgh8LRXGLGWCqpjUuu-Cyb1vYfon-pKQbyDkvy1nWw",
 		title: "LazyShell - AI CLI",
 		body: "A CLI tool that uses generative AI to generate shell commands",
 		href: myGithubUrl + "/lazyshell",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,7 @@ const projects = [
 		title: "LazyShell - AI CLI",
 		body: "A CLI tool that uses generative AI to generate shell commands",
 		href: myGithubUrl + "/lazyshell",
-		techs: ["AI", "CLI", "Shell", "Linux", "OpenAI", "Anthropic", "Claude"]
+		techs: ["AI", "CLI", "Typescript", "Node.js"]
 	},
 	{
 		src: "images/dns-image.webp",


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new LazyShell AI CLI project and streamline GitHub links by centralizing the base URL into constants.

New Features:
- Add LazyShell - AI CLI project card.

Enhancements:
- Replace hardcoded GitHub URLs with a githubUrl constant and derive project links via myGithubUrl.